### PR TITLE
[NOT FOR LANDING] Intentionally crash mha_varlen_fwd to test conda pkg building

### DIFF
--- a/csrc/flash_attn/flash_api.cpp
+++ b/csrc/flash_attn/flash_api.cpp
@@ -526,6 +526,7 @@ mha_varlen_fwd(const at::Tensor &q,  // total_q x num_heads x head_size, total_q
 
     auto opts = q.options();
 
+    TORCH_CHECK(false, "Intentional crash here.")
     auto softmax_lse = torch::empty({num_heads, total_q}, opts.dtype(at::kFloat));
     at::Tensor p;
     // Only return softmax if there's dropout to reduce compilation time


### PR DESCRIPTION
We use this PR to build a conda pkg to run test_cp ensuring that our Diff building conda pkg is correct.

Diff link: https://www.internalfb.com/diff/D55725272

Change from
```
  memo builder::clone "flash-attn" "git@github.com:GD06/flash-attention.git" "softmax_lse_fix"
```

to 
```
  memo builder::clone "flash-attn" "git@github.com:GD06/flash-attention.git" "assert_false"
```

Then run test_cp to check whether the unit test crash.