### PR TITLE
Softmax lse fix non varseq

### DIFF
--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -127,13 +127,9 @@ inline __device__ void compute_dot_do_o(const Params &params) {
         + m_block * kBlockM * params.do_row_stride + bidh * params.do_head_stride;
     const index_t row_offset_o = binfo.q_offset(params.o_batch_stride, params.o_row_stride, bidb)
         + m_block * kBlockM * params.o_row_stride + bidh * params.o_head_stride;
-
     const index_t row_offset_dq_accum = binfo.q_offset(params.seqlen_q_rounded * params.h * params.d_rounded, params.h * params.d_rounded, bidb)
         + (m_block * kBlockM + (params.cu_seqlens_q == nullptr ? 0 : 128 * bidb)) * params.h * params.d_rounded + bidh * params.d_rounded;
 
-    // const index_t row_offset_dpsum = (bidb * params.h + bidh) * params.seqlen_q_rounded + m_block * kBlockM;
-    // const index_t row_offset_dpsum = bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb)
-    //     + 128 * bidb + m_block * kBlockM;
     const index_t row_offset_dpsum = bidh * (binfo.sum_s_q == -1 ? params.seqlen_q_rounded * params.b : params.total_q + 128 * params.b)
         + binfo.q_offset(params.seqlen_q_rounded, 1, bidb) + (binfo.sum_s_q == -1 ? 0 : 128 * bidb)
         + m_block * kBlockM;
@@ -476,12 +472,6 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
     //     + (m_block_max - 1) * kBlockM;
     const index_t row_offset_lse = bidh * params.total_q + binfo.q_offset(params.seqlen_q, 1, bidb)
         + (m_block_max - 1) * kBlockM;
-    // const index_t row_offset_dpsum = (bidb * params.h + bidh) * params.seqlen_q_rounded
-    //     + (m_block_max - 1) * kBlockM;
-    // const index_t row_offset_dpsum = bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb)
-    //     + 128 * bidb + (m_block_max - 1) * kBlockM;
-    // const index_t row_offset_dpsum = bidh * (params.b * params.seqlen_q_rounded) + params.seqlen_q_rounded * bidb
-    //     + (m_block_max - 1) * kBlockM;
     const index_t row_offset_dpsum = bidh * (binfo.sum_s_q == -1 ? params.b * params.seqlen_q_rounded : params.total_q + 128 * params.b)
         + binfo.q_offset(params.seqlen_q_rounded, 1, bidb) + (binfo.sum_s_q == -1 ? 0 : 128 * bidb)
         + (m_block_max - 1) * kBlockM;

--- a/csrc/flash_attn/src/flash_bwd_kernel.h
+++ b/csrc/flash_attn/src/flash_bwd_kernel.h
@@ -127,11 +127,16 @@ inline __device__ void compute_dot_do_o(const Params &params) {
         + m_block * kBlockM * params.do_row_stride + bidh * params.do_head_stride;
     const index_t row_offset_o = binfo.q_offset(params.o_batch_stride, params.o_row_stride, bidb)
         + m_block * kBlockM * params.o_row_stride + bidh * params.o_head_stride;
+
     const index_t row_offset_dq_accum = binfo.q_offset(params.seqlen_q_rounded * params.h * params.d_rounded, params.h * params.d_rounded, bidb)
         + (m_block * kBlockM + (params.cu_seqlens_q == nullptr ? 0 : 128 * bidb)) * params.h * params.d_rounded + bidh * params.d_rounded;
+
     // const index_t row_offset_dpsum = (bidb * params.h + bidh) * params.seqlen_q_rounded + m_block * kBlockM;
-    const index_t row_offset_dpsum = bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb)
-        + 128 * bidb + m_block * kBlockM;
+    // const index_t row_offset_dpsum = bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb)
+    //     + 128 * bidb + m_block * kBlockM;
+    const index_t row_offset_dpsum = bidh * (binfo.sum_s_q == -1 ? params.seqlen_q_rounded * params.b : params.total_q + 128 * params.b)
+        + binfo.q_offset(params.seqlen_q_rounded, 1, bidb) + (binfo.sum_s_q == -1 ? 0 : 128 * bidb)
+        + m_block * kBlockM;
 
     Tensor gdO = make_tensor(make_gmem_ptr(reinterpret_cast<Element *>(params.do_ptr) + row_offset_do),
                              Shape<Int<kBlockM>, Int<kHeadDim>>{},
@@ -473,8 +478,13 @@ inline __device__ void compute_dq_dk_dv_1colblock(const Params &params, const in
         + (m_block_max - 1) * kBlockM;
     // const index_t row_offset_dpsum = (bidb * params.h + bidh) * params.seqlen_q_rounded
     //     + (m_block_max - 1) * kBlockM;
-    const index_t row_offset_dpsum = bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb)
-        + 128 * bidb + (m_block_max - 1) * kBlockM;
+    // const index_t row_offset_dpsum = bidh * (params.total_q + 128 * params.b) + binfo.q_offset(params.seqlen_q_rounded, 1, bidb)
+    //     + 128 * bidb + (m_block_max - 1) * kBlockM;
+    // const index_t row_offset_dpsum = bidh * (params.b * params.seqlen_q_rounded) + params.seqlen_q_rounded * bidb
+    //     + (m_block_max - 1) * kBlockM;
+    const index_t row_offset_dpsum = bidh * (binfo.sum_s_q == -1 ? params.b * params.seqlen_q_rounded : params.total_q + 128 * params.b)
+        + binfo.q_offset(params.seqlen_q_rounded, 1, bidb) + (binfo.sum_s_q == -1 ? 0 : 128 * bidb)
+        + (m_block_max - 1) * kBlockM;
 
     Tensor gQ = make_tensor(make_gmem_ptr(reinterpret_cast<Element *>(params.q_ptr) + row_offset_q),
                             Shape<Int<kBlockM>, Int<kHeadDim>>{},

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2006,10 +2006,21 @@ def test_flash_attn_bwd_transpose(seqlen, d, causal, dtype):
         torch.randn([batch_size, seqlen, nheads, d], dtype=dtype, device="cuda", requires_grad=True)
         for _ in range(3)
     ]
+
     out = rearrange(flash_attn_func(q, k, v, causal=causal), "b s ... -> s b ...")
     # So g is not contiguous
     g = torch.randn(seqlen, 2 * batch_size, nheads, d, dtype=dtype, device="cuda")[:, ::2]
     out.backward(g)
+
+    # out = flash_attn_func(q, k, v, causal=causal)
+    # # out = rearrange(flash_attn_func(q, k, v, causal=causal), "b s ... -> s b ...")
+    # # So g is contiguous
+    # # g = torch.randn(seqlen, batch_size, nheads, d, dtype=dtype, device="cuda")
+    # g = torch.randn(batch_size, seqlen, nheads, d, dtype=dtype, device="cuda")
+    # # g = torch.randn_like(out)
+    # # g = torch.randn_like(out)
+    # out.backward(g)
+
     q_pt = q.detach().clone().requires_grad_(True)
     k_pt = k.detach().clone().requires_grad_(True)
     v_pt = v.detach().clone().requires_grad_(True)

--- a/tests/test_flash_attn.py
+++ b/tests/test_flash_attn.py
@@ -2006,21 +2006,10 @@ def test_flash_attn_bwd_transpose(seqlen, d, causal, dtype):
         torch.randn([batch_size, seqlen, nheads, d], dtype=dtype, device="cuda", requires_grad=True)
         for _ in range(3)
     ]
-
     out = rearrange(flash_attn_func(q, k, v, causal=causal), "b s ... -> s b ...")
     # So g is not contiguous
     g = torch.randn(seqlen, 2 * batch_size, nheads, d, dtype=dtype, device="cuda")[:, ::2]
     out.backward(g)
-
-    # out = flash_attn_func(q, k, v, causal=causal)
-    # # out = rearrange(flash_attn_func(q, k, v, causal=causal), "b s ... -> s b ...")
-    # # So g is contiguous
-    # # g = torch.randn(seqlen, batch_size, nheads, d, dtype=dtype, device="cuda")
-    # g = torch.randn(batch_size, seqlen, nheads, d, dtype=dtype, device="cuda")
-    # # g = torch.randn_like(out)
-    # # g = torch.randn_like(out)
-    # out.backward(g)
-
     q_pt = q.detach().clone().requires_grad_(True)
     k_pt = k.detach().clone().requires_grad_(True)
     v_pt = v.detach().clone().requires_grad_(True)


### PR DESCRIPTION
Add the general supports for non var seq cases, to save memory for softmax_lse.

- Install

```
with-proxy python setup.py develop 2>&1 | tee out.log
```
- Test
```
 pytest  tests/test_flash_attn.py -k test_flash_attn_causal -x 2>&1 | tee log.txt
 pytest  tests/test_flash_attn.py -k test_flash_attn_bwd_transpose -x 2>&1 | tee log.txt
```


https://www.internalfb.com/intern/paste/P1205198147/

 pytest  tests/test_flash_attn.py -x 2>&1 | tee log.txt
P1219468821

```
........................................................................ [ 99%]
........................................................................ [ 99%]
.....................................................................    [100%]

============== 201764 passed, 84480 skipped in 2091.37s (0:34:51) ==============
```